### PR TITLE
Update ruby version matrix

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -21,8 +21,8 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        ruby-version: ['2.4', '2.5','2.6', '2.7', '3.0', '3.1']
+        matrix:
+          ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- update the spacing in the `ruby-version` matrix of the rspec workflow

## Testing
- `bundle install`
- `bundle exec rake spec`

------
https://chatgpt.com/codex/tasks/task_e_6841a2337dc483318106721cae3ceaa8