### PR TITLE
Fix README example for Ipepe/MultipleConditionUnless

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ unless foo && bar
 end
 
 # good
-if foo || bar
+if !(foo && bar)
   do_something
 end
 ```


### PR DESCRIPTION
## Summary
- clarify good example for Ipepe/MultipleConditionUnless cop in README

## Testing
- `bundle exec rake spec` *(fails: rbenv: version `2.7.8` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841a234e4448331a6c0b3435aa688a8