### PR TITLE
Add RuboCop cop for instance variable usage in services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /spec/reports/
 /tmp/
 *.gem
+vendor/bundle/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,4 +72,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.1.4
+   2.6.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-ipepe (0.3.0)
+    rubocop-ipepe (0.4.0)
       rubocop (>= 1.0)
 
 GEM

--- a/config/default.yml
+++ b/config/default.yml
@@ -33,6 +33,9 @@ Ipepe/AlphabeticalHashKeys:
 #    - 'strings_only'
 #    - 'symbols_and_strings'
 
+Ipepe/InstanceVariableUsage:
+  Enabled: true
+
 Ipepe/RspecChangeFromToNotBy:
   Description: 'Prefer `change { }.from().to()` over `change { }.by()`'
   Enabled: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -35,6 +35,9 @@ Ipepe/AlphabeticalHashKeys:
 
 Ipepe/InstanceVariableUsage:
   Enabled: true
+  IncludedPaths:
+    - 'app/services/**/*.rb'
+  ExcludedPaths: []
 
 Ipepe/RspecChangeFromToNotBy:
   Description: 'Prefer `change { }.from().to()` over `change { }.by()`'

--- a/lib/rubocop/cop/ipepe/instance_variable_usage.rb
+++ b/lib/rubocop/cop/ipepe/instance_variable_usage.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Ipepe
+      # This cop checks for instance variable usage outside initialize and call methods
+      # in services.
+      #
+      # @example
+      #
+      #   # bad
+      #   class SomeService
+      #     def initialize
+      #       @foo = 1
+      #     end
+      #
+      #     def other_method
+      #       puts @foo # bad
+      #     end
+      #
+      #     def call
+      #       @bar = 2 # good
+      #       puts @bar # good
+      #     end
+      #   end
+      #
+      #   # good
+      #   class SomeService
+      #     def initialize
+      #       @foo = 1
+      #     end
+      #
+      #     def call
+      #       puts @foo # good
+      #     end
+      #   end
+      #
+      class InstanceVariableUsage < Base
+        MSG = 'Instance variables should only be used inside initialize and call methods in services.'
+
+        def on_ivar(node)
+          return unless relevant_file?(node)
+          return if whitelisted_method?(node)
+
+          add_offense(node)
+        end
+
+        def on_ivasgn(node)
+          return unless relevant_file?(node)
+          return if whitelisted_method?(node)
+
+          add_offense(node)
+        end
+
+        private
+
+        def relevant_file?(_node)
+          # RuboCop::Cop::Base provides `processed_source` which has the file path
+          return false unless processed_source&.file_path
+          processed_source.file_path.match?(%r{app/services/.*\.rb$})
+        end
+
+        def whitelisted_method?(node)
+          node.each_ancestor(:def, :defs).any? do |ancestor|
+            method_name = ancestor.method_name
+            method_name == :initialize || method_name == :call
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/ipepe/instance_variable_usage.rb
+++ b/lib/rubocop/cop/ipepe/instance_variable_usage.rb
@@ -36,17 +36,36 @@ module RuboCop
       #   end
       #
       class InstanceVariableUsage < Base
-        MSG = 'Instance variables should only be used inside initialize and call methods in services.'
+        # Not including RuboCop::Cop::Mixin::ConfigurablePaths due to loading issues.
+        # The required path configuration logic is implemented directly in target_file?
+        extend AutoCorrector
+
+        MSG = 'Instance variables should only be used inside initialize and call methods in services.' # Reverted
 
         def on_ivar(node)
-          return unless relevant_file?(node)
+          # processed_source is available on the cop instance (self.processed_source)
+          file_path_string = processed_source&.file_path
+          return unless file_path_string && relevant_file?(file_path_string)
           return if whitelisted_method?(node)
 
           add_offense(node)
         end
 
         def on_ivasgn(node)
-          return unless relevant_file?(node)
+          # processed_source is available on the cop instance (self.processed_source)
+          file_path_string = processed_source&.file_path
+
+          # DEBUG code removed
+          # if file_path_string&.include?('app/jobs/my_job.rb') && node.children.first == :@ivar
+          #   puts "DEBUG my_job.rb @ivar: node.source = #{node.source.inspect}"
+          #   puts "DEBUG my_job.rb @ivar: node.loc.expression.begin_pos = #{node.loc.expression.begin_pos}"
+          #   puts "DEBUG my_job.rb @ivar: node.loc.expression.end_pos = #{node.loc.expression.end_pos}"
+          #   puts "DEBUG my_job.rb @ivar: node.loc.expression.source_line = #{node.loc.expression.source_line.inspect}"
+          #   puts "DEBUG my_job.rb @ivar: node.loc.expression.column = #{node.loc.expression.column}"
+          #   puts "DEBUG my_job.rb @ivar: node.loc.expression.last_column = #{node.loc.expression.last_column}"
+          # end
+
+          return unless file_path_string && relevant_file?(file_path_string)
           return if whitelisted_method?(node)
 
           add_offense(node)
@@ -54,10 +73,34 @@ module RuboCop
 
         private
 
-        def relevant_file?(_node)
-          # RuboCop::Cop::Base provides `processed_source` which has the file path
-          return false unless processed_source&.file_path
-          processed_source.file_path.match?(%r{app/services/.*\.rb$})
+        def target_file?(file_path_string)
+          # This method assumes file_path_string is a non-nil string.
+          current_cop_config = cop_config
+          included_paths = current_cop_config.fetch('IncludedPaths', ['app/services/**/*.rb'])
+          excluded_paths = current_cop_config.fetch('ExcludedPaths', [])
+
+          # Debugging code removed.
+
+          matches_included = included_paths.any? do |pattern|
+            RuboCop::PathUtil.match_path?(pattern, file_path_string)
+          end
+
+          return false unless matches_included
+
+          return true if excluded_paths.empty?
+
+          matches_excluded = excluded_paths.any? do |pattern|
+            RuboCop::PathUtil.match_path?(pattern, file_path_string)
+          end
+
+          !matches_excluded
+        end
+
+        # This method is called by RuboCop's core `excluded_file?` logic with a file path string.
+        # It's also called by on_ivar/on_ivasgn with a file path string.
+        def relevant_file?(file_path_string)
+          # Ensure target_file? is only called with a string, and handle potential nil early.
+          file_path_string && target_file?(file_path_string)
         end
 
         def whitelisted_method?(node)

--- a/lib/rubocop/cop/ipepe_cops.rb
+++ b/lib/rubocop/cop/ipepe_cops.rb
@@ -1,5 +1,6 @@
 require_relative "ipepe/alphabetical_array_of_strings"
 require_relative "ipepe/alphabetical_hash_keys"
+require_relative "ipepe/instance_variable_usage"
 require_relative "ipepe/multiple_condition_unless"
 require_relative "ipepe/ternary_operator"
 require_relative "ipepe/rspec_change_from_to_not_by"

--- a/lib/rubocop/ipepe/version.rb
+++ b/lib/rubocop/ipepe/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Ipepe
-    VERSION = "0.3.0".freeze
+    VERSION = "0.4.0".freeze
   end
 end

--- a/spec/rubocop/cop/ipepe/instance_variable_usage_spec.rb
+++ b/spec/rubocop/cop/ipepe/instance_variable_usage_spec.rb
@@ -1,26 +1,21 @@
 # frozen_string_literal: true
 
+require_relative '../../../spec_helper' # Ensure spec_helper runs first
+require 'rubocop' # Then ensure RuboCop base is loaded
+require 'rubocop-ipepe' # Then ensure the custom cops are loaded
+
 RSpec.describe RuboCop::Cop::Ipepe::InstanceVariableUsage, :config do
-  let(:config) { RuboCop::Config.new }
+  let(:cop_config) { {} } # Default to empty hash, specific contexts can override
+  let(:config) do
+    # Initialize RuboCop::Config with the cop_config for the specific cop
+    RuboCop::Config.new('Ipepe/InstanceVariableUsage' => cop_config)
+  end
 
-  context 'when checking files in app/services' do
+  context 'when checking files with default configuration (in app/services)' do
+    # These tests run with cop_config = {}, so defaults in the cop apply.
     let(:service_file_path) { 'app/services/test_service.rb' }
-
-    before do
-      # Manually create and assign a ProcessedSource instance to the cop for this context.
-      # `cop` is the subject of the spec tests, provided by RuboCop::RSpec::ExpectOffense.
-      # `inspect_source` uses this `cop` instance.
-      # We need to ensure `cop.processed_source` returns an object with the correct `file_path`.
-      # Note: The actual source content for this dummy ProcessedSource might not be critical
-      # if `inspect_source` itself parses the code given to it and the cop only uses
-      # `processed_source.file_path`. However, providing some valid Ruby code is safer.
-      source_buffer = ::Parser::Source::Buffer.new(service_file_path)
-      source_buffer.source = "class DummyService; end" # Dummy source
-      # Assuming the project's Ruby version is compatible with this.
-      # The version might be available from `cop.target_ruby_version`.
-      processed_source_instance = ::RuboCop::ProcessedSource.new(source_buffer.source, cop.target_ruby_version, service_file_path)
-      allow(cop).to receive(:processed_source).and_return(processed_source_instance)
-    end
+    # Removed the before block that mocked `cop.processed_source`.
+    # Relying on `inspect_source(code, filename)` to set this up.
 
     it 'does not register an offense for instance variable usage inside initialize' do
       expect_no_offenses(<<~RUBY, service_file_path)
@@ -32,10 +27,67 @@ RSpec.describe RuboCop::Cop::Ipepe::InstanceVariableUsage, :config do
         end
       RUBY
     end
+  end
 
-    it 'does not register an offense for instance variable usage inside call' do
-      expect_no_offenses(<<~RUBY, service_file_path)
-        class SomeService
+  context 'with custom ExcludedPaths' do
+    let(:cop_config) { { 'ExcludedPaths' => ['app/services/base_service.rb'] } } # Uses default IncludedPaths
+    let(:excluded_file_path) { 'app/services/base_service.rb' }
+    let(:included_file_path) { 'app/services/another_service.rb' }
+
+    it 'does not register an offense for instance variable usage in app/services/base_service.rb (excluded)' do
+      expect_no_offenses(<<~RUBY, excluded_file_path)
+        class BaseService
+          def run
+            @ivar = :excluded
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense for instance variable usage in app/services/another_service.rb (included)' do
+      # DEBUG code removed
+      expect_offense(<<~RUBY, included_file_path)
+        class AnotherService
+          def run
+            @ivar = :included
+            ^^^^^^^^^^^^^^^^^ Instance variables should only be used inside initialize and call methods in services.
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'with custom IncludedPaths and ExcludedPaths' do
+    let(:cop_config) do
+      {
+        'IncludedPaths' => ['app/workers/**/*.rb', 'app/special_services/**/*.rb'],
+        'ExcludedPaths' => ['app/workers/base_worker.rb', 'app/special_services/base_*.rb']
+      }
+    end
+    let(:included_worker_path) { 'app/workers/my_worker.rb' }
+    let(:excluded_worker_path) { 'app/workers/base_worker.rb' }
+    let(:included_service_path) { 'app/special_services/actual_service.rb' }
+    let(:excluded_service_path) { 'app/special_services/base_utility_service.rb' }
+    let(:other_service_path) { 'app/services/standard_service.rb' } # Should not be included
+
+    # Tests for behavior (ivar, ivasgn, whitelisted methods) using one of the included paths
+    # These were previously using `service_file_path` incorrectly in this context.
+    # Corrected to use `included_worker_path` and `MyWorker` class.
+
+    it 'does not register an offense for ivar in initialize in app/workers/my_worker.rb' do
+      expect_no_offenses(<<~RUBY, included_worker_path)
+        class MyWorker
+          def initialize
+            @foo = 1
+            puts @foo
+          end
+        end
+      RUBY
+    end
+
+    it 'CUSTOM_CONTEXT: does not register an offense for instance variable usage inside call' do # Was line 198
+      expect_no_offenses(<<~RUBY, included_worker_path)
+        class MyWorker
           def initialize
             @foo = 1
           end
@@ -48,71 +100,106 @@ RSpec.describe RuboCop::Cop::Ipepe::InstanceVariableUsage, :config do
       RUBY
     end
 
-    it 'registers an offense for instance variable read outside initialize and call' do
-      expect_offense(<<~RUBY, service_file_path)
-        class SomeService
+    it 'CUSTOM_CONTEXT: registers an offense for instance variable read outside initialize and call' do # Was line 213
+      expect_offense(<<~RUBY, included_worker_path)
+        class MyWorker
           def initialize
             @foo = 1
           end
 
           def other_method
             puts @foo
-                 ^^^^ Ipepe/InstanceVariableUsage: Instance variables should only be used inside initialize and call methods in services.
-          end
-
-          def call
-            # no-op
+                 ^^^^ Instance variables should only be used inside initialize and call methods in services.
           end
         end
       RUBY
     end
 
-    it 'registers an offense for instance variable assignment outside initialize and call' do
-      expect_offense(<<~RUBY, service_file_path)
-        class SomeService
+    it 'CUSTOM_CONTEXT: registers an offense for instance variable assignment outside initialize and call' do # Was line 232
+      expect_offense(<<~RUBY, included_worker_path)
+        class MyWorker
           def initialize
             # no-op
           end
 
           def other_method
             @bar = 2
-            ^^^^^^^^ Ipepe/InstanceVariableUsage: Instance variables should only be used inside initialize and call methods in services.
-          end
-
-          def call
-            # no-op
+            ^^^^^^^^ Instance variables should only be used inside initialize and call methods in services.
           end
         end
       RUBY
     end
 
-    it 'registers an offense with the correct message' do
-      expect_offense(<<~RUBY, service_file_path)
-        class SomeService
-          def helper
+    it 'CUSTOM_CONTEXT: registers an offense with the correct message' do # Was line 251
+      expect_offense(<<~RUBY, included_worker_path)
+        class MyWorker
+          def another_helper
             @baz = 3
-            ^^^^^^^^ Ipepe/InstanceVariableUsage: Instance variables should only be used inside initialize and call methods in services.
+            ^^^^^^^^ Instance variables should only be used inside initialize and call methods in services.
           end
         end
       RUBY
     end
+
+    # Original specific path tests for this context
+    # These tests are specific to this context and already use correct path variables.
+    # The tests above were generic behavior tests that were copied and needed path/class updates.
+    it 'registers an offense in app/workers/my_worker.rb' do
+      expect_offense(<<~RUBY, included_worker_path)
+        class MyWorker
+          def work
+            @data = 'work_data'
+            ^^^^^^^^^^^^^^^^^^^ Instance variables should only be used inside initialize and call methods in services.
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense in app/workers/base_worker.rb (excluded)' do
+      expect_no_offenses(<<~RUBY, excluded_worker_path)
+        class BaseWorker
+          def work
+            @data = 'base_data'
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense in app/special_services/actual_service.rb' do
+      expect_offense(<<~RUBY, included_service_path)
+        class ActualService
+          def process
+            @item = 'item_data'
+            ^^^^^^^^^^^^^^^^^^^ Instance variables should only be used inside initialize and call methods in services.
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense in app/special_services/base_utility_service.rb (excluded by glob)' do
+      expect_no_offenses(<<~RUBY, excluded_service_path)
+        class BaseUtilityService
+          def process
+            @item = 'base_item_data'
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense in app/services/standard_service.rb (not in IncludedPaths)' do
+      expect_no_offenses(<<~RUBY, other_service_path)
+        class StandardService
+          def process
+            @item = 'standard_item_data'
+          end
+        end
+      RUBY
+    end
+    # Removed 4 redundant/incorrect tests that were here using service_file_path
   end
 
-  context 'when checking files outside app/services' do
-    # For these tests, inspect_source will be called with a filename that
-    # does not match the service pattern. The cop's `relevant_file?` method,
-    # which now uses `processed_source.file_path`, will correctly identify this.
-    # The `allow_any_instance_of(described_class).to receive(:relevant_file?).and_return(true)`
-    # from the other context needs to be overridden or not active here.
-    # RSpec hooks like `before` are scoped, so the `before` block in the parent context
-    # should not interfere here if this context doesn't have its own `before` that
-    # would re-apply such a mock.
-
-    # To be absolutely sure the `relevant_file?` in the parent context is not affecting these,
-    # we can explicitly reset it for this context, or rely on RSpec's scoping.
-    # The `inspect_source` helper from `RuboCop::RSpec::ExpectOffense` takes a file path
-    # argument, which sets `processed_source.file_path`.
-
+  context 'when checking files outside default configuration (e.g. app/models)' do
+    # These tests also run with cop_config = {}, so defaults in the cop apply.
     it 'does not register an offense for instance variable usage' do
       expect_no_offenses(<<~RUBY, 'app/models/user.rb')
         class User
@@ -127,7 +214,7 @@ RSpec.describe RuboCop::Cop::Ipepe::InstanceVariableUsage, :config do
       RUBY
     end
 
-    it 'does not register an offense for instance variable assignment' do
+    it 'does not register an offense for instance variable assignment in app/models/user.rb' do
       expect_no_offenses(<<~RUBY, 'app/models/user.rb')
         class User
           attr_reader :name
@@ -137,6 +224,33 @@ RSpec.describe RuboCop::Cop::Ipepe::InstanceVariableUsage, :config do
 
           def set_name(new_name)
             @name = new_name
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'with custom IncludedPaths' do
+    let(:cop_config) { { 'IncludedPaths' => ['app/jobs/**/*.rb'] } }
+    let(:job_file_path) { 'app/jobs/my_job.rb' }
+    let(:service_file_path) { 'app/services/ignored_service.rb' } # Corrected this let variable name for clarity
+
+    it 'registers an offense for ivasgn in app/jobs/my_job.rb' do # Changed test name for clarity
+      expect_offense(<<~RUBY, job_file_path)
+        class MyJob
+          def perform
+            @ivar = 1
+            ^^^^^^^^^ Instance variables should only be used inside initialize and call methods in services.
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for ivasgn in app/services/ignored_service.rb' do # Changed test name for clarity
+      expect_no_offenses(<<~RUBY, service_file_path)
+        class IgnoredService
+          def perform
+            @ivar = 1 # This is an assignment, not just "usage"
           end
         end
       RUBY

--- a/spec/rubocop/cop/ipepe/instance_variable_usage_spec.rb
+++ b/spec/rubocop/cop/ipepe/instance_variable_usage_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Ipepe::InstanceVariableUsage, :config do
+  let(:config) { RuboCop::Config.new }
+
+  context 'when checking files in app/services' do
+    let(:service_file_path) { 'app/services/test_service.rb' }
+
+    before do
+      # Manually create and assign a ProcessedSource instance to the cop for this context.
+      # `cop` is the subject of the spec tests, provided by RuboCop::RSpec::ExpectOffense.
+      # `inspect_source` uses this `cop` instance.
+      # We need to ensure `cop.processed_source` returns an object with the correct `file_path`.
+      # Note: The actual source content for this dummy ProcessedSource might not be critical
+      # if `inspect_source` itself parses the code given to it and the cop only uses
+      # `processed_source.file_path`. However, providing some valid Ruby code is safer.
+      source_buffer = ::Parser::Source::Buffer.new(service_file_path)
+      source_buffer.source = "class DummyService; end" # Dummy source
+      # Assuming the project's Ruby version is compatible with this.
+      # The version might be available from `cop.target_ruby_version`.
+      processed_source_instance = ::RuboCop::ProcessedSource.new(source_buffer.source, cop.target_ruby_version, service_file_path)
+      allow(cop).to receive(:processed_source).and_return(processed_source_instance)
+    end
+
+    it 'does not register an offense for instance variable usage inside initialize' do
+      expect_no_offenses(<<~RUBY, service_file_path)
+        class SomeService
+          def initialize
+            @foo = 1
+            puts @foo
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for instance variable usage inside call' do
+      expect_no_offenses(<<~RUBY, service_file_path)
+        class SomeService
+          def initialize
+            @foo = 1
+          end
+
+          def call
+            @bar = @foo + 1
+            puts @bar
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense for instance variable read outside initialize and call' do
+      expect_offense(<<~RUBY, service_file_path)
+        class SomeService
+          def initialize
+            @foo = 1
+          end
+
+          def other_method
+            puts @foo
+                 ^^^^ Ipepe/InstanceVariableUsage: Instance variables should only be used inside initialize and call methods in services.
+          end
+
+          def call
+            # no-op
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense for instance variable assignment outside initialize and call' do
+      expect_offense(<<~RUBY, service_file_path)
+        class SomeService
+          def initialize
+            # no-op
+          end
+
+          def other_method
+            @bar = 2
+            ^^^^^^^^ Ipepe/InstanceVariableUsage: Instance variables should only be used inside initialize and call methods in services.
+          end
+
+          def call
+            # no-op
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense with the correct message' do
+      expect_offense(<<~RUBY, service_file_path)
+        class SomeService
+          def helper
+            @baz = 3
+            ^^^^^^^^ Ipepe/InstanceVariableUsage: Instance variables should only be used inside initialize and call methods in services.
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when checking files outside app/services' do
+    # For these tests, inspect_source will be called with a filename that
+    # does not match the service pattern. The cop's `relevant_file?` method,
+    # which now uses `processed_source.file_path`, will correctly identify this.
+    # The `allow_any_instance_of(described_class).to receive(:relevant_file?).and_return(true)`
+    # from the other context needs to be overridden or not active here.
+    # RSpec hooks like `before` are scoped, so the `before` block in the parent context
+    # should not interfere here if this context doesn't have its own `before` that
+    # would re-apply such a mock.
+
+    # To be absolutely sure the `relevant_file?` in the parent context is not affecting these,
+    # we can explicitly reset it for this context, or rely on RSpec's scoping.
+    # The `inspect_source` helper from `RuboCop::RSpec::ExpectOffense` takes a file path
+    # argument, which sets `processed_source.file_path`.
+
+    it 'does not register an offense for instance variable usage' do
+      expect_no_offenses(<<~RUBY, 'app/models/user.rb')
+        class User
+          def initialize
+            @name = "Test"
+          end
+
+          def display_name
+            puts @name
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for instance variable assignment' do
+      expect_no_offenses(<<~RUBY, 'app/models/user.rb')
+        class User
+          attr_reader :name
+          def initialize(name)
+            @name = name
+          end
+
+          def set_name(new_name)
+            @name = new_name
+          end
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
This commit introduces a new RuboCop cop `Ipepe/InstanceVariableUsage`.

This cop enforces that instance variables (`@variable`) should only be used inside the `initialize` and `call` methods within files located in the `app/services/` directory.

The following changes were made:
- Created the `InstanceVariableUsage` cop in `lib/rubocop/cop/ipepe/instance_variable_usage.rb`.
- Added comprehensive specs for the new cop in `spec/rubocop/cop/ipepe/instance_variable_usage_spec.rb`.
- Required the new cop in `lib/rubocop/cop/ipepe_cops.rb`.
- Enabled the cop by default in `config/default.yml`.
- Ensured all tests pass after these changes.