### PR TITLE
Add RuboCop cop for non-standard Rails actions

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -33,6 +33,11 @@ Ipepe/AlphabeticalHashKeys:
 #    - 'strings_only'
 #    - 'symbols_and_strings'
 
+Ipepe/RailsNonStandardActions:
+  Description: 'Non-standard Rails actions should be defined as sub-controllers'
+  Enabled: true
+  VersionAdded: '0.4.0'
+
 Ipepe/RspecChangeFromToNotBy:
   Description: 'Prefer `change { }.from().to()` over `change { }.by()`'
   Enabled: true

--- a/lib/rubocop/cop/ipepe/rails_non_standard_actions.rb
+++ b/lib/rubocop/cop/ipepe/rails_non_standard_actions.rb
@@ -1,0 +1,38 @@
+module RuboCop
+  module Cop
+    module Ipepe
+      class RailsNonStandardActions < ::RuboCop::Cop::Base
+        MSG = "Non-standard Rails actions should be defined as sub-controllers".freeze
+
+        STANDARD_ACTIONS = %i[index show new edit create update destroy].freeze
+
+        def on_def(node)
+          return unless in_controller_class?(node)
+
+          method_name = node.method_name
+          return if STANDARD_ACTIONS.include?(method_name)
+
+          add_offense(node, message: format_message(method_name))
+        end
+
+        private
+
+        def in_controller_class?(node)
+          class_node = node.each_ancestor(:class).first
+          return false unless class_node
+
+          class_name = class_node.identifier.source
+          class_name.end_with?("Controller")
+        end
+
+        def format_message(method_name)
+          "Non-standard action '#{method_name}' should be moved to a sub-controller (e.g., #{suggested_controller_name(method_name)})"
+        end
+
+        def suggested_controller_name(method_name)
+          "#{method_name.to_s.capitalize}Controller"
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/ipepe_cops.rb
+++ b/lib/rubocop/cop/ipepe_cops.rb
@@ -1,5 +1,6 @@
 require_relative "ipepe/alphabetical_array_of_strings"
 require_relative "ipepe/alphabetical_hash_keys"
 require_relative "ipepe/multiple_condition_unless"
-require_relative "ipepe/ternary_operator"
+require_relative "ipepe/rails_non_standard_actions"
 require_relative "ipepe/rspec_change_from_to_not_by"
+require_relative "ipepe/ternary_operator"

--- a/lib/rubocop/ipepe/version.rb
+++ b/lib/rubocop/ipepe/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Ipepe
-    VERSION = "0.3.0".freeze
+    VERSION = "0.5.0".freeze
   end
 end

--- a/spec/rubocop/cop/ipepe/rails_non_standard_actions_spec.rb
+++ b/spec/rubocop/cop/ipepe/rails_non_standard_actions_spec.rb
@@ -1,0 +1,112 @@
+require "spec_helper"
+
+RSpec.describe RuboCop::Cop::Ipepe::RailsNonStandardActions, :config do
+  let(:config) do
+    RuboCop::Config.new("AllCops" => {
+                          "DisplayCopNames" => true
+                        })
+  end
+
+  context "when class is a controller" do
+    it "registers an offense for non-standard action" do
+      expect_offense <<~RUBY
+        class BooksController
+          def download
+              ^^^^^^^^ Ipepe/RailsNonStandardActions: Non-standard action 'download' should be moved to a sub-controller (e.g., DownloadController)
+          end
+        end
+      RUBY
+    end
+
+    it "registers multiple offenses for multiple non-standard actions" do
+      expect_offense <<~RUBY
+        class BooksController
+          def download
+              ^^^^^^^^ Ipepe/RailsNonStandardActions: Non-standard action 'download' should be moved to a sub-controller (e.g., DownloadController)
+          end
+
+          def export
+              ^^^^^^ Ipepe/RailsNonStandardActions: Non-standard action 'export' should be moved to a sub-controller (e.g., ExportController)
+          end
+        end
+      RUBY
+    end
+
+    it "does not register an offense for standard actions" do
+      expect_no_offenses <<~RUBY
+        class BooksController
+          def index
+          end
+
+          def show
+          end
+
+          def new
+          end
+
+          def edit
+          end
+
+          def create
+          end
+
+          def update
+          end
+
+          def destroy
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when class is not a controller" do
+    it "does not register an offense for non-standard methods" do
+      expect_no_offenses <<~RUBY
+        class Book
+          def download
+          end
+
+          def export
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "with nested controller class" do
+    it "registers an offense for non-standard action in nested controller" do
+      expect_offense <<~RUBY
+        module Admin
+          class BooksController
+            def download
+                ^^^^^^^^ Ipepe/RailsNonStandardActions: Non-standard action 'download' should be moved to a sub-controller (e.g., DownloadController)
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "with mixed standard and non-standard actions" do
+    it "only registers offenses for non-standard actions" do
+      expect_offense <<~RUBY
+        class BooksController
+          def index
+          end
+
+          def download
+              ^^^^^^^^ Ipepe/RailsNonStandardActions: Non-standard action 'download' should be moved to a sub-controller (e.g., DownloadController)
+          end
+
+          def show
+          end
+
+          def export
+              ^^^^^^ Ipepe/RailsNonStandardActions: Non-standard action 'export' should be moved to a sub-controller (e.g., ExportController)
+          end
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Implements Ipepe/RailsNonStandardActions cop that detects non-standard Rails controller actions and suggests refactoring them into sub-controllers.

Closes #27

Generated with [Claude Code](https://claude.ai/code)